### PR TITLE
fix: fix friends get route in testConfig

### DIFF
--- a/backend/config/testConfig.ts
+++ b/backend/config/testConfig.ts
@@ -92,7 +92,7 @@ app.get(
 
 app.post("/friend", friendController.friend_add_post);
 app.post("/friend/request", friendController.friend_request_post);
-app.get("/friends", friendController.user_friends);
+app.get("/friends", friendController.user_friends_get);
 
 app.use(notFoundErrorMiddleware);
 app.use(errorMiddleware);


### PR DESCRIPTION
Update friends get route in the testConfig to use the correct controller name.