### PR TITLE
Update client seeding scripts

### DIFF
--- a/backend/@types/scriptTypes.ts
+++ b/backend/@types/scriptTypes.ts
@@ -14,8 +14,11 @@ type SeedUserGenerator = {
   community: string;
 };
 
+type ClientUserGenerator = SeedUserGenerator;
+
 export type {
   CommunityWithOwnerAndInbox,
   CommunitiesWithOwnerAndIInbox,
   SeedUserGenerator,
+  ClientUserGenerator,
 };

--- a/backend/database/prisma/scriptQueries.ts
+++ b/backend/database/prisma/scriptQueries.ts
@@ -33,6 +33,16 @@ const getSeedUsers = async (): GetSeedUsersData => {
   return user;
 };
 
+const getClientUsers = () => {
+  return prisma.user.findMany({
+    where: {
+      username: {
+        startsWith: "clientuser",
+      },
+    },
+  });
+};
+
 const deleteUserFriends = async (userId: string) => {
   await prisma.friend.deleteMany({
     where: {
@@ -132,6 +142,16 @@ const getSeedCommunities = async () => {
   });
 
   return communities;
+};
+
+const getClientCommunities = async () => {
+  return prisma.community.findMany({
+    where: {
+      name: {
+        startsWith: "clientcommunity",
+      },
+    },
+  });
 };
 
 const getCommunityOwner = async (communityId: string): Promise<User | null> => {
@@ -266,6 +286,7 @@ type CreateCommunityMember = {
   userId: string;
   status: ParticipantStatus;
 };
+
 const createCommunityMember = ({
   status,
   userId,
@@ -472,14 +493,32 @@ const deleteUserMessages = async (id: string) => {
   });
 };
 
+type CreateCommunityMessage = CreateCommunitySeedMessage;
+
+const createCommunityMessage = async ({
+  number,
+  inboxId,
+  authorId,
+}: CreateCommunityMessage) => {
+  await prisma.message.create({
+    data: {
+      content: `seedmessage${number}`,
+      inboxId: inboxId,
+      authorId: authorId,
+    },
+  });
+};
+
 export {
   getUserByUsername,
   getSeedUsers,
+  getClientUsers,
   getSeedUsersToPopulateFriends,
   deleteUserFriends,
   createFriendsRelationship,
   getSeedCommunities,
   getSeedCommunitiesWithOwnerAndInbox,
+  getClientCommunities,
   deleteCommunityMessages,
   createCommunitySeedMessage,
   deleteUserNotifications,
@@ -495,4 +534,5 @@ export {
   getSeedLoneUsers,
   deleteUser,
   deleteUserMessages,
+  createCommunityMessage,
 };

--- a/backend/scripts/clientPopulateDB.ts
+++ b/backend/scripts/clientPopulateDB.ts
@@ -1,100 +1,182 @@
 #!/usr/bin/env node
 import { User } from "@prisma/client";
-import prisma from "../database/prisma/client";
 import bcrypt from "bcrypt";
-// Populate database for testing purposes
-const populateDB = async () => {
-  console.log(`\x1b[36mPopulating database for client testing...`);
-  try {
-    // Create Users
-    const users: {
-      username: string;
-      displayName: string;
-      password: string;
-      community: string;
-    }[] = [
-      {
-        username: "clientuser1",
-        displayName: "clientuser1",
-        password: "client@User1",
-        community: "clientcommunity1",
-      },
-      {
-        username: "clientuser2",
-        displayName: "clientuser2",
-        password: "client@User2",
-        community: "clientcommunity2",
-      },
-    ];
+import {
+  logErrorMessage,
+  logPopulateMessage,
+  logPopulateSuccessMessage,
+} from "../utils/loggerUtils";
+import { generateClientUserGenerators } from "../utils/scriptUtils";
+import {
+  createCommunity,
+  createCommunityMessage,
+  createUser,
+  getClientUsers,
+  getCommunityWithOwnerAndInboxByName,
+} from "../database/prisma/scriptQueries";
+import { createTimer, pause } from "../utils/timeUtils";
+import { ClientUserGenerator } from "../@types/scriptTypes";
 
-    for (const user of users) {
-      const createUserData = async () => {
-        bcrypt.hash(user.password, 10, async (err, hashedPassword) => {
-          if (err) {
-            console.error(err);
-          }
+type GenerateClientUser = {
+  username: string;
+  displayName: string;
+  password: string;
+};
 
-          const userData: User = await prisma.user.create({
-            data: {
-              username: user.username,
-              displayName: user.username,
-              password: hashedPassword,
-            },
+const generateClientUser = async ({
+  username,
+  displayName,
+  password,
+}: GenerateClientUser) => {
+  const createUserPromise = async () =>
+    new Promise((resolve, reject) => {
+      bcrypt.hash(password, 10, async (err, hashedPassword) => {
+        if (err) {
+          logErrorMessage(err);
+          reject(err);
+        } else {
+          await createUser({
+            username,
+            displayName,
+            password: hashedPassword,
           });
+          resolve(1);
+        }
+      });
+    });
 
-          // Create communities
-          const community = await prisma.community.create({
-            data: {
-              name: user.community,
-              bio: user.community,
-              inbox: {
-                create: {
-                  inboxType: "COMMUNITY",
-                },
-              },
-              participants: {
-                create: {
-                  userId: userData.id,
-                  role: "OWNER",
-                  status: "ACTIVE",
-                  memberSince: new Date(),
-                },
-              },
-            },
-            include: {
-              inbox: true,
-            },
-          });
+  await createUserPromise();
+};
 
-          if (community?.inbox) {
-            for (let i = 1; i <= 100; i++) {
-              await new Promise(resolve => setTimeout(resolve, 1000));
+type GenerateCommunityMessages = {
+  name: string;
+  authorId: string;
+  messageCount: number;
+};
 
-              const message = await prisma.message.create({
-                data: {
-                  content: `clientmessage${i}`,
-                  inboxId: community.inbox?.id,
-                  authorId: userData.id,
-                },
-              });
+const generateCommunityMessages = async ({
+  name,
+  authorId,
+  messageCount,
+}: GenerateCommunityMessages) => {
+  const community = await getCommunityWithOwnerAndInboxByName(name);
 
-              console.log(
-                `\x1b[36mFinished created message: ${message.content}`,
-              );
-            }
-          }
+  if (community?.inbox) {
+    const messageInflection = messageCount > 1 ? "messages" : "message";
+    logPopulateMessage(
+      `Creating ${messageCount} ${messageInflection} for ${community.name}`,
+    );
 
-          console.log(
-            `\x1b[36mFinished populating database for ${user.username}`,
-          );
-        });
-      };
-
-      await createUserData();
+    for (let i = 1; i <= messageCount; i++) {
+      await pause(100);
+      await createCommunityMessage({
+        number: i,
+        inboxId: community.inbox.id,
+        authorId: authorId,
+      });
     }
-  } catch (err) {
-    if (err instanceof Error) console.error(`\x1b[31m${err.message}`);
+
+    logPopulateSuccessMessage(
+      `Successfully created ${messageCount} ${messageInflection}` +
+        ` for ${community.name}`,
+    );
   }
 };
 
-populateDB();
+type GenerateClientCommunities = {
+  clientUsers: User[];
+  clientUserGenerators: ClientUserGenerator[];
+};
+
+const generateClientCommunities = ({
+  clientUsers,
+  clientUserGenerators,
+}: GenerateClientCommunities) => {
+  return clientUserGenerators.map(async (clientUserGenerator, index) => {
+    logPopulateMessage(
+      `Creating user ${clientUserGenerator.username}'s community` +
+        ` ${clientUserGenerator.community}...`,
+    );
+    const community = await createCommunity({
+      name: clientUserGenerator.community,
+      bio: clientUserGenerator.community,
+      ownerId: clientUsers[index].id,
+    });
+    logPopulateSuccessMessage(
+      `Successfully created user ${clientUserGenerator.username}'s` +
+        ` community ${clientUserGenerator.community}`,
+    );
+
+    await generateCommunityMessages({
+      name: community.name,
+      authorId: clientUsers[index].id,
+      messageCount: 100,
+    });
+
+    logPopulateMessage(
+      `Successfully created ${clientUserGenerator.username} and its data`,
+    );
+  });
+};
+
+const doArraysHaveEqualLength = <TypeOne, TypeTwo>(
+  arrayOne: TypeOne[],
+  arrayTwo: TypeTwo[],
+) => {
+  return arrayOne.length === arrayTwo.length;
+};
+
+type PopulateClientCommunities = {
+  clientUsers: User[];
+  clientUserGenerators: ClientUserGenerator[];
+};
+
+const populateClientCommunities = async ({
+  clientUsers,
+  clientUserGenerators,
+}: PopulateClientCommunities) => {
+  if (doArraysHaveEqualLength(clientUsers, clientUserGenerators)) {
+    await Promise.all(
+      generateClientCommunities({ clientUsers, clientUserGenerators }),
+    );
+  } else {
+    throw new Error("arrays have different lengths");
+  }
+};
+
+const populateClientUsers = async (
+  clientUserGenerators: ClientUserGenerator[],
+): Promise<User[]> => {
+  for (const clientUserGenerator of clientUserGenerators) {
+    logPopulateMessage(
+      `Creating ${clientUserGenerator.username} and its data...`,
+    );
+    await generateClientUser({
+      username: clientUserGenerator.username,
+      displayName: clientUserGenerator.displayName,
+      password: clientUserGenerator.password,
+    });
+  }
+
+  const clientUsers = await getClientUsers();
+  return clientUsers;
+};
+
+const populateClientDB = async () => {
+  logPopulateMessage("Populating database...");
+  const timer = createTimer();
+  try {
+    const clientUserGenerators = generateClientUserGenerators(2);
+    const clientUsers = await populateClientUsers(clientUserGenerators);
+    await populateClientCommunities({ clientUserGenerators, clientUsers });
+  } catch (err) {
+    logErrorMessage(err);
+  } finally {
+    timer.stopTimer();
+    const timeInSecond = timer.timeInSecond;
+    logPopulateSuccessMessage("Finished populating database");
+    logPopulateSuccessMessage(`${timeInSecond} s`);
+  }
+};
+
+populateClientDB();

--- a/backend/scripts/clientUnpopulateDB.ts
+++ b/backend/scripts/clientUnpopulateDB.ts
@@ -1,187 +1,44 @@
 #!/usr/bin/env node
-import prisma from "../database/prisma/client";
+import {
+  getClientUsers,
+  getClientCommunities,
+} from "../database/prisma/scriptQueries";
+import { User, Community } from "@prisma/client";
+import { unpopulateCommunities, unpopulateUsers } from "./unpopulateScript";
+import {
+  logUnpopulateMessage,
+  logErrorMessage,
+  logUnpopulateSuccessMessage,
+} from "../utils/loggerUtils";
+import { createTimer } from "../utils/timeUtils";
+
+type Unpopulate = {
+  users: User[];
+  communities: Community[];
+};
+
+const unpopulate = async ({ users, communities }: Unpopulate) => {
+  await unpopulateCommunities(communities);
+  await unpopulateUsers(users);
+};
 
 const unpopulateDB = async () => {
-  const clientUsers = [
-    {
-      username: "clientuser1",
-    },
-    {
-      username: "clientuser2",
-    },
-  ];
-
-  const clientCommunity = [
-    {
-      name: "clientcommunity1",
-    },
-    {
-      name: "clientcommunity2",
-    },
-  ];
-
-  const deleteUsers = async ({ username }: { username: string }) => {
-    console.log(`\x1b[31mDeleting ${username} with its associated data`);
-    const user = await prisma.user.findUnique({
-      where: {
-        username: username,
-      },
+  logUnpopulateMessage("Unpopulating database...");
+  const timer = createTimer();
+  try {
+    const seedUsers = await getClientUsers();
+    const seedCommunities = await getClientCommunities();
+    await unpopulate({
+      users: seedUsers,
+      communities: seedCommunities,
     });
-
-    if (user !== null) {
-      const communities = await prisma.community.findMany({
-        where: {
-          participants: {
-            some: {
-              AND: [{ userId: user?.id }, { role: "OWNER" }],
-            },
-          },
-        },
-        include: {
-          inbox: true,
-        },
-      });
-
-      console.log(communities);
-
-      // Delete communities and their related data
-
-      for (const community of communities) {
-        // eslint-disable-next-line
-        const cascadeDelete = async (community: any) => {
-          console.log(
-            `\x1b[31mDeleting ${community.name} and its related data`,
-          );
-
-          const deleteMessages = prisma.message.deleteMany({
-            where: {
-              inboxId: community.inbox?.id as string,
-            },
-          });
-
-          const deleteParticipants = prisma.participant.deleteMany({
-            where: {
-              communityId: community.id,
-            },
-          });
-
-          const deleteInboxes = prisma.inbox.deleteMany({
-            where: {
-              communityId: community.id,
-            },
-          });
-
-          const deleteCommunities = prisma.community.deleteMany({
-            where: {
-              id: community.id,
-            },
-          });
-
-          const deleteNotifications = prisma.notification.deleteMany({
-            where: {
-              triggeredById: user.id,
-            },
-          });
-
-          await prisma.$transaction([
-            deleteMessages,
-            deleteParticipants,
-            deleteInboxes,
-            deleteCommunities,
-            deleteNotifications,
-          ]);
-        };
-
-        await cascadeDelete(community);
-        console.log(`\x1b[31mFinished deleting ${community.name}`);
-      }
-
-      // Delete user
-
-      console.log(`\x1b[31mDeleting ${username}`);
-
-      await prisma.user.delete({
-        where: {
-          username: username,
-        },
-      });
-
-      console.log(`\x1b[31mFinished deleting ${username}`);
-    } else {
-      console.log(`\x1b[33m${username} doesn't exist`);
-    }
-  };
-
-  const deleteCommunity = async ({
-    communityName,
-  }: {
-    communityName: string;
-  }) => {
-    console.log(`\x1b[31mDeleting ${communityName} with its associated data`);
-    const community = await prisma.community.findUnique({
-      where: {
-        name: communityName,
-      },
-    });
-
-    if (community !== null) {
-      // Delete community related data
-      // eslint-disable-next-line
-      const cascadeDelete = async (community: any) => {
-        console.log(`\x1b[31mDeleting ${community.name} and its related data`);
-
-        const deleteMessages = prisma.message.deleteMany({
-          where: {
-            inboxId: community.inbox?.id as string,
-          },
-        });
-
-        const deleteParticipants = prisma.participant.deleteMany({
-          where: {
-            communityId: community.id,
-          },
-        });
-
-        const deleteInbox = prisma.inbox.deleteMany({
-          where: {
-            communityId: community.id,
-          },
-        });
-
-        const deleteCommunity = prisma.community.deleteMany({
-          where: {
-            id: community.id,
-          },
-        });
-
-        await prisma.$transaction([
-          deleteMessages,
-          deleteParticipants,
-          deleteInbox,
-          deleteCommunity,
-        ]);
-      };
-
-      await cascadeDelete(community);
-
-      console.log(`\x1b[31mFinished deleting ${community.name}`);
-    }
-  };
-
-  for (const data of clientUsers) {
-    try {
-      await deleteUsers({ username: data.username });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  for (const community of clientCommunity) {
-    try {
-      await deleteCommunity({ communityName: community.name });
-    } catch (err) {
-      console.log(err);
-    }
+  } catch (err) {
+    logErrorMessage(err);
+  } finally {
+    timer.stopTimer();
+    const timeInSecond = timer.timeInSecond;
+    logUnpopulateSuccessMessage("Finished unpopulating database");
+    logUnpopulateSuccessMessage(`${timeInSecond} s`);
   }
 };
 

--- a/backend/scripts/unpopulateDB.ts
+++ b/backend/scripts/unpopulateDB.ts
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
 import { Community, User } from "@prisma/client";
 import {
-  deleteCommunityAndItsData,
-  deleteUser,
-  deleteUserFriends,
-  deleteUserNotifications,
   getSeedCommunities,
   getSeedLoneUsers,
   getSeedUsers,
@@ -15,67 +11,7 @@ import {
   logUnpopulateSuccessMessage,
 } from "../utils/loggerUtils";
 import { createTimer } from "../utils/timeUtils";
-import { breakArrayIntoSubArrays } from "../utils/array";
-
-const destroyCommunity = async (community: Community) => {
-  try {
-    logUnpopulateMessage(`Deleting ${community.name} with its data...`);
-    await deleteCommunityAndItsData(community.id);
-    logUnpopulateSuccessMessage(
-      `Successfully deleted ${community.name} with its data`,
-    );
-  } catch (err) {
-    logErrorMessage(err);
-  }
-};
-
-const createDeleteCommunitiesPromises = (communities: Community[]) => {
-  return communities.map(async community => {
-    await destroyCommunity(community);
-  });
-};
-
-const unpopulateCommunities = async (communities: Community[]) => {
-  const communitiesSubArrays = breakArrayIntoSubArrays({
-    array: communities,
-    subArraySize: 10,
-  });
-
-  for (const communitiesSubArray of communitiesSubArrays) {
-    await Promise.all(createDeleteCommunitiesPromises(communitiesSubArray));
-  }
-};
-
-const destroyUser = async (user: User) => {
-  try {
-    logUnpopulateMessage(`Deleting ${user.username} with its data...`);
-    await deleteUserNotifications(user.id);
-    await deleteUserFriends(user.id);
-    await deleteUser(user.id);
-    logUnpopulateSuccessMessage(
-      `Successfully deleted ${user.username} with its data`,
-    );
-  } catch (err) {
-    logErrorMessage(err);
-  }
-};
-
-const createDeleteUsersPromises = (users: User[]) => {
-  return users.map(async user => {
-    await destroyUser(user);
-  });
-};
-
-const unpopulateUsers = async (users: User[]) => {
-  const usersSubArrays = breakArrayIntoSubArrays({
-    array: users,
-    subArraySize: 10,
-  });
-
-  for (const usersSubArray of usersSubArrays) {
-    await Promise.all(createDeleteUsersPromises(usersSubArray));
-  }
-};
+import { unpopulateCommunities, unpopulateUsers } from "./unpopulateScript";
 
 type Unpopulate = {
   users: User[];

--- a/backend/scripts/unpopulateScript.ts
+++ b/backend/scripts/unpopulateScript.ts
@@ -1,0 +1,75 @@
+import { Community, User } from "@prisma/client";
+import {
+  logUnpopulateMessage,
+  logUnpopulateSuccessMessage,
+  logErrorMessage,
+} from "../utils/loggerUtils";
+import {
+  deleteCommunityAndItsData,
+  deleteUserNotifications,
+  deleteUser,
+  deleteUserFriends,
+} from "../database/prisma/scriptQueries";
+import { breakArrayIntoSubArrays } from "../utils/array";
+
+const destroyCommunity = async (community: Community) => {
+  try {
+    logUnpopulateMessage(`Deleting ${community.name} with its data...`);
+    await deleteCommunityAndItsData(community.id);
+    logUnpopulateSuccessMessage(
+      `Successfully deleted ${community.name} with its data`,
+    );
+  } catch (err) {
+    logErrorMessage(err);
+  }
+};
+
+const createDeleteCommunitiesPromises = (communities: Community[]) => {
+  return communities.map(async community => {
+    await destroyCommunity(community);
+  });
+};
+
+const unpopulateCommunities = async (communities: Community[]) => {
+  const communitiesSubArrays = breakArrayIntoSubArrays({
+    array: communities,
+    subArraySize: 10,
+  });
+
+  for (const communitiesSubArray of communitiesSubArrays) {
+    await Promise.all(createDeleteCommunitiesPromises(communitiesSubArray));
+  }
+};
+
+const destroyUser = async (user: User) => {
+  try {
+    logUnpopulateMessage(`Deleting ${user.username} with its data...`);
+    await deleteUserNotifications(user.id);
+    await deleteUserFriends(user.id);
+    await deleteUser(user.id);
+    logUnpopulateSuccessMessage(
+      `Successfully deleted ${user.username} with its data`,
+    );
+  } catch (err) {
+    logErrorMessage(err);
+  }
+};
+
+const createDeleteUsersPromises = (users: User[]) => {
+  return users.map(async user => {
+    await destroyUser(user);
+  });
+};
+
+const unpopulateUsers = async (users: User[]) => {
+  const usersSubArrays = breakArrayIntoSubArrays({
+    array: users,
+    subArraySize: 10,
+  });
+
+  for (const usersSubArray of usersSubArrays) {
+    await Promise.all(createDeleteUsersPromises(usersSubArray));
+  }
+};
+
+export { unpopulateUsers, unpopulateCommunities };

--- a/backend/utils/loggerUtils.ts
+++ b/backend/utils/loggerUtils.ts
@@ -1,4 +1,6 @@
 import pino from "pino";
+import dotenv from "dotenv";
+dotenv.config();
 
 const NODE_ENV = process.env.NODE_ENV;
 const isDev = NODE_ENV?.toLowerCase() == "development";

--- a/backend/utils/scriptUtils.ts
+++ b/backend/utils/scriptUtils.ts
@@ -17,4 +17,21 @@ const generateSeedUserGenerators = (size: number): SeedUserGenerator[] => {
   return seedUsers;
 };
 
-export { generateSeedUserGenerators };
+const generateClientUserGenerators = (size: number): SeedUserGenerator[] => {
+  const clientUsers = [];
+
+  for (let i = 1; i <= size; i++) {
+    const user = {
+      username: `clientuser${i}`,
+      displayName: `clientuser${i}`,
+      password: `client@User${i}`,
+      community: `clientcommunity${i}`,
+    };
+
+    clientUsers.push(user);
+  }
+
+  return clientUsers;
+};
+
+export { generateSeedUserGenerators, generateClientUserGenerators };


### PR DESCRIPTION
# Update client seeding scripts

## What changed

- Fixed `unpopulateClientDB`' fails to delete client seed data due incomplete deletion of associated users' friends  data.
- Improved  client seeding files' code quality by breaking big functions into smaller functions.
- Extracted some functions from unpopulate script to be used in other unpopulate related scripts.
- Used `dotenv` to load process env to ensure 'pino' is invoked with the correct options.